### PR TITLE
Feat/flow create campaign

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,8 @@ module.exports = {
     'space-in-parens': 'error',
     'no-multiple-empty-lines': 'error',
     'prefer-const': 'error',
+    'no-empty-function': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   coveragePathIgnorePatterns: ['./test'],
+  globalSetup: '<rootDir>/tests/setup.ts',
+  setupFilesAfterEnv: ['<rootDir>/tests/setup-after-env.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  coveragePathIgnorePatterns: ['./test'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/pg": "^8.6.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "helmet": "^6.0.1",
         "pg": "^8.9.0",
-        "trust-env": "^2.2.1"
+        "trust-env": "^2.2.1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.4.0",
         "@types/node": "^18.14.2",
+        "@types/pg": "^8.6.6",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
         "eslint": "^8.35.0",
@@ -1434,12 +1436,14 @@
     "node_modules/@types/node": {
       "version": "18.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
+      "dev": true
     },
     "node_modules/@types/pg": {
       "version": "8.6.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
       "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -1484,6 +1488,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6195,6 +6205,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7484,12 +7502,14 @@
     "@types/node": {
       "version": "18.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
+      "dev": true
     },
     "@types/pg": {
       "version": "8.6.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
       "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -7534,6 +7554,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/yargs": {
@@ -10931,6 +10957,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "helmet": "^6.0.1",
         "pg": "^8.9.0",
         "trust-env": "^2.2.1",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "zod": "^3.20.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.13",
@@ -23,6 +24,7 @@
         "@types/jest": "^29.4.0",
         "@types/node": "^18.14.2",
         "@types/pg": "^8.6.6",
+        "@types/supertest": "^2.0.12",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
@@ -32,6 +34,7 @@
         "jest": "^29.4.3",
         "nodemon": "^2.0.20",
         "prettier": "^2.8.4",
+        "supertest": "^6.3.3",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
         "tsc-watch": "^6.0.0",
@@ -1341,6 +1344,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "node_modules/@types/cors": {
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
@@ -1489,6 +1498,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.16.tgz",
+      "integrity": "sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/superagent": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "9.0.1",
@@ -2057,6 +2085,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/babel-jest": {
       "version": "29.4.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.3.tgz",
@@ -2446,6 +2486,24 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2489,6 +2547,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -2551,6 +2615,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2575,6 +2648,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -3203,6 +3286,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -3293,6 +3382,35 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3489,6 +3607,15 @@
       "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -5823,6 +5950,108 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+      "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6385,6 +6614,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -7407,6 +7644,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "@types/cors": {
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
@@ -7555,6 +7798,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.16.tgz",
+      "integrity": "sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/uuid": {
       "version": "9.0.1",
@@ -7940,6 +8202,18 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "29.4.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.3.tgz",
@@ -8215,6 +8489,21 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8249,6 +8538,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -8302,6 +8597,12 @@
       "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
       "dev": true
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8317,6 +8618,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff": {
       "version": "4.0.2",
@@ -8778,6 +9089,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -8853,6 +9170,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -8993,6 +9333,12 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
       "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -10715,6 +11061,81 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "superagent": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+      "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11093,6 +11514,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "helmet": "^6.0.1",
     "pg": "^8.9.0",
     "trust-env": "^2.2.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^3.20.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
@@ -29,6 +30,7 @@
     "@types/jest": "^29.4.0",
     "@types/node": "^18.14.2",
     "@types/pg": "^8.6.6",
+    "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
@@ -38,6 +40,7 @@
     "jest": "^29.4.3",
     "nodemon": "^2.0.20",
     "prettier": "^2.8.4",
+    "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "tsc-watch": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -15,19 +15,21 @@
     "format": "prettier --write '**/*.ts'"
   },
   "dependencies": {
-    "@types/pg": "^8.6.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "helmet": "^6.0.1",
     "pg": "^8.9.0",
-    "trust-env": "^2.2.1"
+    "trust-env": "^2.2.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.14.2",
+    "@types/pg": "^8.6.6",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "eslint": "^8.35.0",

--- a/src/controllers/campaign-controller.schema.ts
+++ b/src/controllers/campaign-controller.schema.ts
@@ -1,0 +1,16 @@
+import z from 'zod';
+import { CampaignCurrency } from '../interfaces/domain/campaign.types';
+
+const CreateCampaignSchema = z.object({
+  body: z
+    .object({
+      prefix: z.string().min(1).max(10),
+      fromDate: z.string().datetime(),
+      toDate: z.string().datetime(),
+      amount: z.number().min(1).max(1000000),
+      currency: z.enum([CampaignCurrency.EUR, CampaignCurrency.USD]),
+    })
+    .strict(),
+});
+
+export { CreateCampaignSchema };

--- a/src/controllers/campaign.controller.ts
+++ b/src/controllers/campaign.controller.ts
@@ -1,0 +1,32 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { CreateCampaignDto } from '../interfaces/domain/campaign.types';
+import campaignService from '../services/campaign.service';
+
+const campaignController = {
+  create: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { prefix, fromDate, toDate, amount, currency }: CreateCampaignDto = req.body;
+
+      const startDate = new Date(fromDate);
+      const endDate = new Date(toDate);
+
+      if (startDate.getTime() >= endDate.getTime()) {
+        return res.status(400).send({ error: "The campaign's end date should come after its start date" });
+      }
+
+      const campaign = await campaignService.create({
+        prefix,
+        fromDate: startDate.toISOString(),
+        toDate: endDate.toISOString(),
+        amount,
+        currency,
+      });
+
+      res.status(201).json(campaign);
+    } catch (err: any) {
+      next(err);
+    }
+  },
+};
+
+export default campaignController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import server from './server';
 import env from './env';
 
-const port = Number(env.SERVER_PORT);
+const port = Number(env.SERVER_PORT) || 3000;
 
 (async () => {
   server.listen(port, () => console.log(`Running on port: ${port}`));

--- a/src/interfaces/domain/campaign.types.ts
+++ b/src/interfaces/domain/campaign.types.ts
@@ -13,3 +13,11 @@ export type Campaign = {
   createdAt: Date;
   updatedAt: Date;
 };
+
+export type CreateCampaignDto = {
+  prefix: string;
+  fromDate: string;
+  toDate: string;
+  amount: number;
+  currency: CampaignCurrency;
+};

--- a/src/interfaces/repositories/campaign-repository.port.ts
+++ b/src/interfaces/repositories/campaign-repository.port.ts
@@ -2,4 +2,5 @@ import type { Campaign, CreateCampaignDto } from '../domain/campaign.types';
 
 export interface SqlCampaignRepositoryPort {
   create(input: CreateCampaignDto): Promise<Campaign>;
+  findById(id: string): Promise<Campaign | null>;
 }

--- a/src/interfaces/repositories/campaign-repository.port.ts
+++ b/src/interfaces/repositories/campaign-repository.port.ts
@@ -1,0 +1,5 @@
+import type { Campaign, CreateCampaignDto } from '../domain/campaign.types';
+
+export interface SqlCampaignRepositoryPort {
+  create(input: CreateCampaignDto): Promise<Campaign>;
+}

--- a/src/middlewares/schema-validator.ts
+++ b/src/middlewares/schema-validator.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { AnyZodObject } from 'zod';
+
+const validate = (schema: AnyZodObject) => (req: Request, res: Response, next: NextFunction) => {
+  try {
+    schema.parse({
+      body: req.body,
+      query: req.query,
+      params: req.params,
+    });
+
+    next();
+  } catch (err: any) {
+    return res.status(400).send(err.errors);
+  }
+};
+
+export default validate;

--- a/src/repositories/campaign.repository.ts
+++ b/src/repositories/campaign.repository.ts
@@ -1,0 +1,26 @@
+import type { QueryResult } from 'pg';
+import pool from '../drivers/postgresql';
+import type { Campaign, CreateCampaignDto } from '../interfaces/domain/campaign.types';
+import type { SqlCampaignRepositoryPort } from '../interfaces/repositories/campaign-repository.port';
+import { objectKeysFromSnakeCaseToCamelCase } from '../utils/case-convert';
+
+const pgCampaignRepository: SqlCampaignRepositoryPort = {
+  create: async (input: CreateCampaignDto): Promise<Campaign> => {
+    const queryText = `
+      INSERT INTO campaigns (
+        prefix,
+        from_date,
+        to_date,
+        amount,
+        currency
+      ) VALUES ($1, $2, $3, $4, $5) RETURNING *
+    `;
+    const queryValues = Object.values(input);
+
+    const response = (await pool.query(queryText, queryValues)) as QueryResult<Campaign>;
+
+    return objectKeysFromSnakeCaseToCamelCase(response.rows[0]) as Campaign;
+  },
+};
+
+export default pgCampaignRepository;

--- a/src/repositories/campaign.repository.ts
+++ b/src/repositories/campaign.repository.ts
@@ -21,6 +21,26 @@ const pgCampaignRepository: SqlCampaignRepositoryPort = {
 
     return objectKeysFromSnakeCaseToCamelCase(response.rows[0]) as Campaign;
   },
+
+  async findById(id: string): Promise<Campaign | null> {
+    const queryText = `
+      SELECT
+        *
+      FROM
+        campaigns
+      WHERE
+        id = $1
+    `;
+    const queryValues = [id];
+
+    const response = (await pool.query(queryText, queryValues)) as QueryResult<Campaign>;
+
+    if (response.rows.length) {
+      return response.rows[0];
+    }
+
+    return null;
+  },
 };
 
 export default pgCampaignRepository;

--- a/src/routers/campaign.router.ts
+++ b/src/routers/campaign.router.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import campaignController from '../controllers/campaign.controller';
+import validate from '../middlewares/schema-validator';
+import { CreateCampaignSchema } from '../controllers/campaign-controller.schema';
+
+export default function campaignRouter() {
+  const router = express.Router();
+
+  router.post('/', validate(CreateCampaignSchema), async (req: Request, res: Response, next: NextFunction) =>
+    campaignController.create(req, res, next),
+  );
+
+  return router;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
+import campaignRouter from './routers/campaign.router';
 
 const server = express();
 
@@ -8,5 +9,7 @@ server.use(express.json());
 server.use(express.urlencoded({ extended: true }));
 server.use(helmet());
 server.use(cors());
+
+server.use('/campaigns', campaignRouter());
 
 export default server;

--- a/src/services/campaign.service.ts
+++ b/src/services/campaign.service.ts
@@ -1,0 +1,10 @@
+import type { CreateCampaignDto } from '../interfaces/domain/campaign.types';
+import campaignRepository from '../repositories/campaign.repository';
+
+const campaignService = {
+  create: async (input: CreateCampaignDto) => {
+    return campaignRepository.create(input);
+  },
+};
+
+export default campaignService;

--- a/src/utils/case-convert.ts
+++ b/src/utils/case-convert.ts
@@ -1,0 +1,20 @@
+export function objectKeysFromSnakeCaseToCamelCase(o: any): unknown {
+  if (o === Object(o) && !Array.isArray(o) && typeof o !== 'function' && !(o instanceof Date)) {
+    const n = {} as any;
+    Object.keys(o as object).forEach((k) => {
+      n[stringFromSnakeCaseToCamelCase(k)] = objectKeysFromSnakeCaseToCamelCase(o[k]);
+    });
+    return n;
+  } else if (Array.isArray(o)) {
+    return o.map((i) => {
+      return objectKeysFromSnakeCaseToCamelCase(i);
+    });
+  }
+  return o;
+}
+
+export function stringFromSnakeCaseToCamelCase(s: string): string {
+  return s.replace(/([-_][a-z])/gi, ($1) => {
+    return $1.toUpperCase().replace('-', '').replace('_', '');
+  });
+}

--- a/src/utils/flush.ts
+++ b/src/utils/flush.ts
@@ -1,0 +1,22 @@
+import type { Pool } from 'pg';
+
+export default async (pool: Pool) => {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const queryTextDeleteVouchers = 'DELETE FROM vouchers';
+    const queryTextDeleteCampaigns = 'DELETE FROM campaigns';
+
+    await client.query(queryTextDeleteVouchers);
+    await client.query(queryTextDeleteCampaigns);
+
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+};

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,1 @@
+export { v4 as generateUuid } from 'uuid';

--- a/tests/builders/builder.interface.ts
+++ b/tests/builders/builder.interface.ts
@@ -1,0 +1,5 @@
+export interface BuilderInterface<MODEL_TYPE> {
+  readonly data: any;
+
+  build(): Promise<MODEL_TYPE>;
+}

--- a/tests/builders/campaign.builder.ts
+++ b/tests/builders/campaign.builder.ts
@@ -1,0 +1,65 @@
+import { Campaign, CampaignCurrency } from '../../src/interfaces/domain/campaign.types';
+import type { BuilderInterface } from './builder.interface';
+import pool from '../../src/drivers/postgresql';
+import type { QueryResult } from 'pg';
+import { generateUuid } from '../../src/utils/uuid';
+
+interface CampaignBuilderInterface {
+  id: string;
+  prefix: string;
+  fromDate: Date;
+  toDate: Date;
+  amount: number;
+  currency: CampaignCurrency;
+}
+
+export class CampaignBuilder implements BuilderInterface<Campaign> {
+  readonly data!: CampaignBuilderInterface;
+
+  constructor({
+    id = generateUuid(),
+    prefix = 'RECHARGE',
+    fromDate = new Date('2022-01-01'),
+    toDate = new Date('2023-01-01'),
+    amount = 20,
+    currency = CampaignCurrency.USD,
+  }: {
+    id?: string;
+    prefix?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    amount?: number;
+    currency?: CampaignCurrency;
+  }) {
+    this.data = {
+      id,
+      prefix,
+      fromDate,
+      toDate,
+      amount,
+      currency,
+    };
+  }
+
+  public async build() {
+    const queryText = `
+    INSERT INTO campaigns (
+      id,
+      prefix,
+      from_date,
+      to_date,
+      amount,
+      currency
+    ) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *
+    `;
+    const response = (await pool.query(queryText, Object.values(this.data))) as QueryResult<Campaign>;
+
+    return response.rows[0];
+  }
+
+  public buildMock() {
+    return { ...this.data, createdAt: new Date(), updatedAt: new Date() };
+  }
+}
+
+export const aCampaign = (data: Partial<CampaignBuilderInterface>) => new CampaignBuilder(data);

--- a/tests/integration/repositories/campaign-repository.spec.ts
+++ b/tests/integration/repositories/campaign-repository.spec.ts
@@ -2,6 +2,8 @@ import pool from '../../../src/drivers/postgresql';
 import flush from '../../../src/utils/flush';
 import { CampaignCurrency, CreateCampaignDto } from '../../../src/interfaces/domain/campaign.types';
 import pgCampaignRepository from '../../../src/repositories/campaign.repository';
+import { generateUuid } from '../../../src/utils/uuid';
+import { aCampaign } from '../../builders/campaign.builder';
 
 describe('@repositories/pg-campaign-repository', () => {
   afterEach(async () => {
@@ -27,6 +29,28 @@ describe('@repositories/pg-campaign-repository', () => {
           currency: CAMPAIGN_DTO.currency,
         }),
       );
+    });
+  });
+
+  describe('findById()', () => {
+    describe('when there is no entity', () => {
+      it('returns null', async () => {
+        const [CAMPAIGN_ID_1, CAMPAIGN_ID_2] = [generateUuid(), generateUuid()];
+
+        await aCampaign({ id: CAMPAIGN_ID_1 }).build();
+
+        await expect(pgCampaignRepository.findById(CAMPAIGN_ID_2)).resolves.toBeNull();
+      });
+    });
+
+    describe('when there is entity', () => {
+      it('returns entity', async () => {
+        const CAMPAIGN_ID = generateUuid();
+
+        await aCampaign({ id: CAMPAIGN_ID }).build();
+
+        await expect(pgCampaignRepository.findById(CAMPAIGN_ID)).resolves.toBeDefined();
+      });
     });
   });
 });

--- a/tests/integration/repositories/campaign-repository.spec.ts
+++ b/tests/integration/repositories/campaign-repository.spec.ts
@@ -1,0 +1,32 @@
+import pool from '../../../src/drivers/postgresql';
+import flush from '../../../src/utils/flush';
+import { CampaignCurrency, CreateCampaignDto } from '../../../src/interfaces/domain/campaign.types';
+import pgCampaignRepository from '../../../src/repositories/campaign.repository';
+
+describe('@repositories/pg-campaign-repository', () => {
+  afterEach(async () => {
+    await flush(pool);
+  });
+
+  describe('create()', () => {
+    it('creates and returns a campaign', async () => {
+      const CAMPAIGN_DTO = {
+        prefix: 'RECHARGE',
+        fromDate: '2023-01-01T00:00:00.000Z',
+        toDate: '2023-02-01T00:00:00.000Z',
+        amount: 20,
+        currency: CampaignCurrency.EUR,
+      } as CreateCampaignDto;
+
+      await expect(pgCampaignRepository.create(CAMPAIGN_DTO)).resolves.toEqual(
+        expect.objectContaining({
+          prefix: CAMPAIGN_DTO.prefix,
+          fromDate: new Date(CAMPAIGN_DTO.fromDate),
+          toDate: new Date(CAMPAIGN_DTO.toDate),
+          amount: CAMPAIGN_DTO.amount,
+          currency: CAMPAIGN_DTO.currency,
+        }),
+      );
+    });
+  });
+});

--- a/tests/integration/routers/campaign-router.spec.ts
+++ b/tests/integration/routers/campaign-router.spec.ts
@@ -1,0 +1,90 @@
+import pool from '../../../src/drivers/postgresql';
+import flush from '../../../src/utils/flush';
+import request from 'supertest';
+import server from '../../../src/server';
+import { CampaignCurrency } from '../../../src/interfaces/domain/campaign.types';
+import pgCampaignRepository from '../../../src/repositories/campaign.repository';
+
+describe('@routers/campaign-router', () => {
+  afterEach(async () => {
+    await flush(pool);
+  });
+
+  describe('POST /campaigns', () => {
+    describe('when payload is not valid', () => {
+      describe('when payload schema types is not valid', () => {
+        it('should return status code 400', async () => {
+          // Amount should be above 0
+          const REQUEST = {
+            prefix: '1',
+            fromDate: '2022-01-01T00:00:00Z',
+            toDate: '2022-01-02T00:00:00Z',
+            amount: -1,
+            currency: CampaignCurrency.EUR,
+          };
+
+          const response = await request(server).post('/campaigns').send(REQUEST);
+
+          expect(response.status).toBe(400);
+        });
+      });
+
+      describe("when campaign's start date comes after its end date", () => {
+        it('should return status code 400', async () => {
+          const REQUEST = {
+            prefix: '1',
+            fromDate: '2022-01-02T00:00:00Z',
+            toDate: '2022-01-01T00:00:00Z',
+            amount: 10,
+            currency: CampaignCurrency.EUR,
+          };
+
+          const response = await request(server).post('/campaigns').send(REQUEST);
+
+          expect(response.status).toBe(400);
+        });
+      });
+
+      describe("when campaign's start date equals to its end date", () => {
+        it('should return status code 400', async () => {
+          const REQUEST = {
+            prefix: '1',
+            fromDate: '2022-01-01T00:00:00Z',
+            toDate: '2022-01-01T00:00:00Z',
+            amount: 10,
+            currency: CampaignCurrency.EUR,
+          };
+
+          const response = await request(server).post('/campaigns').send(REQUEST);
+
+          expect(response.status).toBe(400);
+        });
+      });
+    });
+
+    describe('when payload schema is valid', () => {
+      it('should create entity and return it with status code 201', async () => {
+        const REQUEST = {
+          prefix: '1',
+          fromDate: '2022-01-01T00:00:00Z',
+          toDate: '2022-01-02T00:00:00Z',
+          amount: 10,
+          currency: CampaignCurrency.EUR,
+        };
+
+        const { status, body } = await request(server).post('/campaigns').send(REQUEST);
+
+        expect(status).toBe(201);
+        expect(body).toEqual(
+          expect.objectContaining({
+            prefix: REQUEST.prefix,
+            amount: REQUEST.amount,
+            currency: REQUEST.currency,
+          }),
+        );
+
+        await expect(pgCampaignRepository.findById(body.id)).resolves.toBeDefined();
+      });
+    });
+  });
+});

--- a/tests/mocks/campaign.repository.ts
+++ b/tests/mocks/campaign.repository.ts
@@ -1,0 +1,8 @@
+import type { Campaign } from '../../src/interfaces/domain/campaign.types';
+import type { SqlCampaignRepositoryPort } from '../../src/interfaces/repositories/campaign-repository.port';
+
+const aCampaignRepository: SqlCampaignRepositoryPort = {
+  create: jest.fn(async () => ({} as Promise<Campaign>)),
+};
+
+export default aCampaignRepository;

--- a/tests/mocks/campaign.repository.ts
+++ b/tests/mocks/campaign.repository.ts
@@ -3,6 +3,7 @@ import type { SqlCampaignRepositoryPort } from '../../src/interfaces/repositorie
 
 const aCampaignRepository: SqlCampaignRepositoryPort = {
   create: jest.fn(async () => ({} as Promise<Campaign>)),
+  findById: jest.fn(async () => ({} as Promise<Campaign>)),
 };
 
 export default aCampaignRepository;

--- a/tests/mocks/campaign.service.ts
+++ b/tests/mocks/campaign.service.ts
@@ -1,0 +1,7 @@
+import type { Campaign } from '../../src/interfaces/domain/campaign.types';
+
+const aCampaignService = {
+  create: jest.fn(async () => ({} as Promise<Campaign>)),
+};
+
+export default aCampaignService;

--- a/tests/mocks/express-api.ts
+++ b/tests/mocks/express-api.ts
@@ -1,0 +1,11 @@
+import type { Request, Response, NextFunction } from 'express';
+
+const mockRequest = {} as Request;
+const mockResponse = {
+  send: jest.fn(() => mockResponse),
+  json: jest.fn(() => mockResponse),
+  status: jest.fn(() => mockResponse),
+} as unknown as Response;
+const mockNext = jest.fn() as NextFunction;
+
+export { mockRequest, mockResponse, mockNext };

--- a/tests/setup-after-env.ts
+++ b/tests/setup-after-env.ts
@@ -1,0 +1,5 @@
+import pool from '../src/drivers/postgresql';
+
+afterAll(async () => {
+  pool.end();
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,5 @@
+import { config } from 'dotenv';
+
+config({ path: '.env.test' });
+
+export default () => {};

--- a/tests/unit/controllers/campaign-controller.spec.ts
+++ b/tests/unit/controllers/campaign-controller.spec.ts
@@ -1,0 +1,86 @@
+import aCampaignService from '../../mocks/campaign.service';
+jest.mock('../../../src/services/campaign.service', () => aCampaignService);
+
+import type { Request } from 'express';
+import campaignController from '../../../src/controllers/campaign.controller';
+import { aCampaign } from '../../builders/campaign.builder';
+import { mockNext, mockResponse } from '../../mocks/express-api';
+
+describe('@controllers/campaign-controller', () => {
+  let req: Request;
+
+  beforeEach(() => {
+    req = {} as Request;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create()', () => {
+    describe("when campaign's start date comes after its end date", () => {
+      it('should send response once with status code 400', async () => {
+        const campaign = aCampaign({}).buildMock();
+        const FROM_DATE = new Date('2023').toISOString();
+        const TO_DATE = new Date('2022').toISOString();
+
+        req = {
+          body: {
+            prefix: campaign.prefix,
+            fromDate: FROM_DATE,
+            toDate: TO_DATE,
+            amount: campaign.amount,
+            currency: campaign.currency,
+          },
+        } as Request;
+
+        await campaignController.create(req, mockResponse, mockNext);
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        expect(mockResponse.send).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when campaign's start date equals to its end date", () => {
+      it('should send response once with status code 400', async () => {
+        const campaign = aCampaign({}).buildMock();
+        const DATE = new Date('2023').toISOString();
+
+        req = {
+          body: {
+            prefix: campaign.prefix,
+            fromDate: DATE,
+            toDate: DATE,
+            amount: campaign.amount,
+            currency: campaign.currency,
+          },
+        } as Request;
+
+        await campaignController.create(req, mockResponse, mockNext);
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        expect(mockResponse.send).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when payload is valid', () => {
+      it('should send response with created campaign and status code 201', async () => {
+        const campaign = aCampaign({}).buildMock();
+        (aCampaignService.create as jest.Mock).mockResolvedValueOnce(campaign);
+
+        req = {
+          body: {
+            prefix: campaign.prefix,
+            fromDate: campaign.fromDate,
+            toDate: campaign.toDate,
+            amount: campaign.amount,
+            currency: campaign.currency,
+          },
+        } as Request;
+
+        await campaignController.create(req, mockResponse, mockNext);
+        expect(mockResponse.status).toHaveBeenCalledWith(201);
+        expect(mockResponse.json).toHaveBeenCalledTimes(1);
+        expect(mockResponse.json).toHaveBeenCalledWith(campaign);
+      });
+    });
+  });
+});

--- a/tests/unit/services/campaign-service.spec.ts
+++ b/tests/unit/services/campaign-service.spec.ts
@@ -1,0 +1,26 @@
+import aCampaignRepository from '../../mocks/campaign.repository';
+jest.mock('../../../src/repositories/campaign.repository', () => aCampaignRepository);
+
+import campaignService from '../../../src/services/campaign.service';
+import { aCampaign } from '../../builders/campaign.builder';
+
+describe('@services/campaign-service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create()', () => {
+    it('returns created campaign', async () => {
+      const campaign = aCampaign({}).buildMock();
+      (aCampaignRepository.create as jest.Mock).mockResolvedValueOnce(campaign);
+      const result = await campaignService.create({
+        prefix: campaign.prefix,
+        fromDate: campaign.fromDate.toISOString(),
+        toDate: campaign.toDate.toISOString(),
+        amount: campaign.amount,
+        currency: campaign.currency,
+      });
+      expect(result).toEqual(campaign);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "sourceMap": true,
-    "rootDir": "src",
     "outDir": "dist",
     "importsNotUsedAsValues": "error",
     "esModuleInterop": true,


### PR DESCRIPTION
### Context
Add ability to create campaign

### Changes
- Add `pgCampaignRepository`:
  - methods `create`, `findById`;
  - mock;
  - integration tests;
  - `campaign` entity builder.
- Add `campaignService`:
  - method `create`;
  - mock;
  - unit tests.
- Add `campaignController`:
  - method `create`;
  - unit tests.
- Add `campaignRouter`:
  - method `POST /`;
  - integrations tests;
  - plug router into the server;
  - `zod` validation.

### Other changes
- Update lint, ts, jest configs;
- Add jest test setups;
- Utils: `objectKeysFromSnakeCaseToCamelCase`, `flush, `uuid` utilities.